### PR TITLE
Fix file path separator in supplement function

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,7 +90,7 @@ def ai_detect_page():
 def supplement():
    # Read data from the CSV file
     supplement_data = []
-    with open('Model_assest\supplement_info.csv', 'r') as csvfile:
+    with open('Model_assest/supplement_info.csv', 'r') as csvfile:  # just changing here sign '\' to '/' 
         reader = csv.DictReader(csvfile)
         for row in reader:
             supplement_data.append({


### PR DESCRIPTION
Changed file path separator from '\' to '/' for compatibility.

from -- with open('Model_assest\supplement_info.csv', 'r') as csvfile:
to -- with open('Model_assest/supplement_info.csv', 'r') as csvfile:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling for better cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->